### PR TITLE
Correct spelling of Cocoapods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ router.open(NSURL(string: "routing://route?foo=bar")!) // query paremeters will 
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 
-Via [Cocoapods](https://cocoapods.org):
+Via [CocoaPods](https://cocoapods.org):
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
